### PR TITLE
Throw exception when route is not defined

### DIFF
--- a/src/Stubs/js-routes.stub
+++ b/src/Stubs/js-routes.stub
@@ -6,7 +6,7 @@ function JsRoute() {
     this.get = function (name, parameters = []) {
 
         if (this.routes[name] === undefined) {
-            return '';
+            throw 'Route ' + name + ' is not defined';
         }
 
         return _parseParams(this.routes[name], parameters);
@@ -14,9 +14,9 @@ function JsRoute() {
 
     function _parseParams(route, parameters) {
 
-        if (route.parameters === undefined) return route.url;
-
         let result = '/' + route.url;
+
+        if (route.parameters === undefined) return result;
 
         route.parameters.forEach((param) => {
             if (parameters[param] === undefined) {


### PR DESCRIPTION
- fix return url when route has no paramters.
- bug: returns relative path when route has no paramters, it should return an absolute path.